### PR TITLE
xmi_main_options: add support for default seeds

### DIFF
--- a/bin/xmimsim-gui-batch.c
+++ b/bin/xmimsim-gui-batch.c
@@ -98,6 +98,7 @@ struct options_widget {
 	GtkWidget *poisson_prefsW;
 	GtkWidget *escape_peaks_prefsW;
 	GtkWidget *advanced_compton_prefsW;
+	GtkWidget *default_seeds_prefsW;
 	GtkWidget *custom_detector_response_prefsE;
 	GtkWidget *custom_detector_response_prefsB;
 	GtkWidget *custom_detector_response_prefsC;
@@ -1692,6 +1693,15 @@ static struct options_widget *create_options_frame(GtkWidget *main_window) {
 	}
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(rv->advanced_compton_prefsW),xpv.b);
 	gtk_box_pack_start(GTK_BOX(rv->superframe), rv->advanced_compton_prefsW, TRUE, FALSE, 0);
+
+	rv->default_seeds_prefsW = gtk_check_button_new_with_label("Enable default seeds support");
+	gtk_widget_set_tooltip_text(rv->default_seeds_prefsW, "Enabling this feature will set the seeds that will be used during the simulation to default values, instead of random ones. This is useful when exactly reproducible simulation results are required, usually for testing purposes");
+	if (xmimsim_gui_get_prefs(XMIMSIM_GUI_PREFS_DEFAULT_SEEDS, &xpv) == 0) {
+		//abort
+		preferences_error_handler(main_window);
+	}
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(rv->default_seeds_prefsW),xpv.b);
+	gtk_box_pack_start(GTK_BOX(rv->superframe), rv->default_seeds_prefsW, TRUE, FALSE, 0);
 
 #if defined(HAVE_OPENCL_CL_H) || defined(HAVE_CL_CL_H)
 	rv->opencl_prefsW = gtk_check_button_new_with_label("Enable OpenCL");

--- a/bin/xmimsim-gui-batch.c
+++ b/bin/xmimsim-gui-batch.c
@@ -502,7 +502,7 @@ static int archive_options(GtkWidget *main_window, struct xmi_input *input, stru
 
 	gtk_window_set_title(GTK_WINDOW(wizard), "Simulation options");
 	//add intro page
-	GtkWidget *introLabel = gtk_label_new("Use this wizard to set the simulation options and to set the range of values that the selected parameter(s) will assume. Afterwards, the batch simulation interface will be produced: launch the simulations by clicking the \"\xe2\x96\xb8\" button. Afterwards an interface will be produced that will allow the user to inspect the results of the simulations.");
+	GtkWidget *introLabel = gtk_label_new("Use this wizard to set the simulation options and to set the range of values that the selected parameter(s) will assume.\nAfterwards, the batch simulation interface will be produced: launch the simulations by clicking the \"\xe2\x96\xb8\" button.\nFinally an interface will be produced that will allow the user to inspect the results of the simulations.");
 	gtk_label_set_line_wrap(GTK_LABEL(introLabel), TRUE);
 	gtk_assistant_append_page(GTK_ASSISTANT(wizard), introLabel);
 	gtk_assistant_set_page_complete(GTK_ASSISTANT(wizard), introLabel, TRUE);
@@ -3612,6 +3612,14 @@ GtkWidget *get_inputfile_treeview(struct xmi_input *input, int with_colors) {
 		g_free(buffer);
 		g_free(buffer2);
 	}
+
+	// ensure scrolled_window expands on Gtk3
+#if GTK_MAJOR_VERSION == 3
+	gtk_widget_set_hexpand(scrolled_window, TRUE);
+	gtk_widget_set_vexpand(scrolled_window, TRUE);
+#endif
+	gtk_container_set_border_width(GTK_CONTAINER(scrolled_window), 5);
+
 	return scrolled_window;
 }
 

--- a/bin/xmimsim-gui-prefs.h
+++ b/bin/xmimsim-gui-prefs.h
@@ -51,6 +51,8 @@ enum {
 	//gboolean
 	XMIMSIM_GUI_PREFS_NOTIFICATIONS,
 #endif
+	//gboolean
+	XMIMSIM_GUI_PREFS_DEFAULT_SEEDS,
 	//gchar *
 	XMIMSIM_GUI_PREFS_CUSTOM_DETECTOR_RESPONSE,
 	//struct xmi_ebel_parameters*

--- a/bin/xmimsim.c
+++ b/bin/xmimsim.c
@@ -150,6 +150,8 @@ XMI_MAIN
 		{"disable-advanced-compton", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &(options.use_advanced_compton), "Disable advanced yet slower Compton simulation (default)", NULL },
 		{"custom-detector-response",0,0,G_OPTION_ARG_FILENAME,&options.custom_detector_response,"Use the supplied library for the detector response routine",NULL},
 		{"set-threads",0,0,G_OPTION_ARG_INT,&(options.omp_num_threads),"Sets the number of threads to NTHREADS (default=max)", "NTHREADS"},
+		{"enable-default-seeds", 0, 0, G_OPTION_ARG_NONE, &(options.use_default_seeds), "Use default seeds for reproducible simulation results", NULL },
+		{"disable-default-seeds", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &(options.use_default_seeds), "Disable default seeds for irreproducible simulation results (default)", NULL },
 		{"verbose", 'v', 0, G_OPTION_ARG_NONE, &(options.verbose), "Verbose mode", NULL },
 		{"very-verbose", 'V', 0, G_OPTION_ARG_NONE, &(options.extra_verbose), "Even more verbose mode", NULL },
 		{"version", 0, 0, G_OPTION_ARG_NONE, &version, "Display version information", NULL },
@@ -188,28 +190,6 @@ XMI_MAIN
 #else
 	g_setenv("LANG","en_US",TRUE);
 #endif
-
-
-	//
-	//options...
-	//1) use M-lines
-	//3) use cascade effect
-	//4) use variance reduction
-	/*
-	options.use_M_lines = 1;
-	options.use_cascade_auger = 1;
-	options.use_cascade_radiative = 1;
-	options.use_variance_reduction = 1;
-	options.use_sum_peaks = 0;
-	options.use_escape_peaks = 1;
-	options.use_poisson = 0;
-	options.verbose = 0;
-	options.use_opencl = 0;
-	options.extra_verbose = 0;
-	options.omp_num_threads = xmi_omp_get_max_threads();
-	options.custom_detector_response = NULL;
-	options.use_advanced_compton = 0;
-	*/
 
 	options = xmi_get_default_main_options();
 

--- a/custom-detector-response/detector-response1.F90
+++ b/custom-detector-response/detector-response1.F90
@@ -179,7 +179,7 @@ channels_convPtr, options, escape_ratiosCPtr, n_interactions&
                         WRITE(output_unit,'(A,I2)') 'Calculating pile-up after interactions: ',&
                         n_interactions
 #endif
-                CALL xmi_detector_sum_peaks(inputF, channels_temp)
+                CALL xmi_detector_sum_peaks(inputF, channels_temp, options)
         ENDIF
 
         ALLOCATE(R(0:nlim+100))
@@ -245,7 +245,7 @@ channels_convPtr, options, escape_ratiosCPtr, n_interactions&
                         WRITE(output_unit,'(A,I2)') 'Calculating Poisson noise after interactions: ',&
                         n_interactions
 #endif
-                CALL xmi_detector_poisson(channels_conv)
+                CALL xmi_detector_poisson(channels_conv, options)
         ENDIF
 
 

--- a/include/xmi_main.h
+++ b/include/xmi_main.h
@@ -41,6 +41,7 @@ struct xmi_main_options {
 	int extra_verbose; //default : 0
 	char *custom_detector_response; //default : NULL
 	int use_advanced_compton; //default : 0
+	int use_default_seeds; // default : 0
 };
 
 struct xmi_main_options xmi_get_default_main_options();

--- a/src/xmi_aux_f.F90
+++ b/src/xmi_aux_f.F90
@@ -327,7 +327,9 @@ TYPE, BIND(C) :: xmi_main_options
         INTEGER (C_INT) :: extra_verbose = 0_C_INT
         TYPE (C_PTR) :: custom_detector_response = C_NULL_PTR
         INTEGER (C_INT) :: use_advanced_compton = 0_C_INT
+        INTEGER (C_INT) :: use_default_seeds = 0_C_INT
 ENDTYPE xmi_main_options
+
 !
 !
 !       xmi_solid_angle: Contains the solid angles for a particular geometry

--- a/src/xmi_main.F90
+++ b/src/xmi_main.F90
@@ -188,8 +188,16 @@ options, brute_historyPtr, var_red_historyPtr, solid_anglesCPtr) BIND(C,NAME='xm
         ALLOCATE(seeds(max_threads))
 
         !fetch some seeds
-        IF (xmi_get_random_numbers(C_LOC(seeds), INT(max_threads,KIND=C_LONG)) == 0) RETURN
-
+        IF (options%use_default_seeds .EQ. 1_C_INT) THEN
+                DO i=1,max_threads
+                        seeds(i) = i
+                ENDDO
+        ELSE
+                IF (xmi_get_random_numbers(C_LOC(seeds), INT(max_threads,KIND=C_LONG)) == 0) THEN
+                        WRITE (error_unit, '(A)') 'Error calling xmi_get_random_number'
+                        RETURN
+                ENDIF
+        ENDIF
 
 
 


### PR DESCRIPTION
allows for reproducible simulations, useful for testing (and testing
only!!!)